### PR TITLE
Fix HashSet modification during enumeration in AimMode/ViewfinderMode filters

### DIFF
--- a/CameraScanner.Maui/Platforms/Android/BarcodeFormatMapper.cs
+++ b/CameraScanner.Maui/Platforms/Android/BarcodeFormatMapper.cs
@@ -54,6 +54,11 @@ namespace CameraScanner.Maui
                     formats |= Barcode.FormatItf;
                 }
 
+                if (barcodeFormats.HasFlag(BarcodeFormats.I2OF5))
+                {
+                    formats |= Barcode.FormatItf;
+                }
+
                 if (barcodeFormats.HasFlag(BarcodeFormats.QR))
                 {
                     formats |= Barcode.FormatQrCode;

--- a/CameraScanner.Maui/Platforms/Android/CameraManager.cs
+++ b/CameraScanner.Maui/Platforms/Android/CameraManager.cs
@@ -460,27 +460,13 @@ namespace CameraScanner.Maui
                                 if (this.cameraView.AimMode)
                                 {
                                     var previewCenter = new Point(this.previewView.Width / 2d, this.previewView.Height / 2d);
-
-                                    foreach (var barcode in barcodeResults)
-                                    {
-                                        if (!barcode.PreviewBoundingBox.Contains(previewCenter))
-                                        {
-                                            barcodeResults.Remove(barcode);
-                                        }
-                                    }
+                                    barcodeResults.RemoveWhere(b => !b.PreviewBoundingBox.Contains(previewCenter));
                                 }
 
                                 if (this.cameraView.ViewfinderMode)
                                 {
                                     var previewRect = new RectF(0f, 0f, this.previewView.Width, this.previewView.Height);
-
-                                    foreach (var barcode in barcodeResults)
-                                    {
-                                        if (!previewRect.Contains(barcode.PreviewBoundingBox))
-                                        {
-                                            barcodeResults.Remove(barcode);
-                                        }
-                                    }
+                                    barcodeResults.RemoveWhere(b => !previewRect.Contains(b.PreviewBoundingBox));
                                 }
 
                                 this.cameraView.DetectionFinished(barcodeResults.ToArray());

--- a/CameraScanner.Maui/Platforms/iOS/BarcodeFormatMapper.cs
+++ b/CameraScanner.Maui/Platforms/iOS/BarcodeFormatMapper.cs
@@ -51,6 +51,8 @@ namespace CameraScanner.Maui
             if (barcodeFormats.HasFlag(BarcodeFormats.ITF))
             {
                 symbologiesList.Add(VNBarcodeSymbology.Itf14);
+                symbologiesList.Add(VNBarcodeSymbology.I2OF5);
+                symbologiesList.Add(VNBarcodeSymbology.I2OF5Checksum);
             }
 
             if (barcodeFormats.HasFlag(BarcodeFormats.QR))

--- a/CameraScanner.Maui/Platforms/iOS/BarcodeFormatMapper.cs
+++ b/CameraScanner.Maui/Platforms/iOS/BarcodeFormatMapper.cs
@@ -51,8 +51,6 @@ namespace CameraScanner.Maui
             if (barcodeFormats.HasFlag(BarcodeFormats.ITF))
             {
                 symbologiesList.Add(VNBarcodeSymbology.Itf14);
-                symbologiesList.Add(VNBarcodeSymbology.I2OF5);
-                symbologiesList.Add(VNBarcodeSymbology.I2OF5Checksum);
             }
 
             if (barcodeFormats.HasFlag(BarcodeFormats.QR))

--- a/CameraScanner.Maui/Platforms/iOS/CameraManager.cs
+++ b/CameraScanner.Maui/Platforms/iOS/CameraManager.cs
@@ -698,27 +698,13 @@ namespace CameraScanner.Maui
                 if (this.cameraView.AimMode)
                 {
                     var previewCenter = new Point(this.previewLayer.Bounds.Width / 2, this.previewLayer.Bounds.Height / 2);
-
-                    foreach (var barcode in this.barcodeResults)
-                    {
-                        if (!barcode.PreviewBoundingBox.Contains(previewCenter))
-                        {
-                            this.barcodeResults.Remove(barcode);
-                        }
-                    }
+                    this.barcodeResults.RemoveWhere(b => !b.PreviewBoundingBox.Contains(previewCenter));
                 }
 
                 if (this.cameraView.ViewfinderMode)
                 {
                     var previewRect = new RectF(0, 0, (float)this.previewLayer.Bounds.Width, (float)this.previewLayer.Bounds.Height);
-
-                    foreach (var barcode in this.barcodeResults)
-                    {
-                        if (!previewRect.Contains(barcode.PreviewBoundingBox))
-                        {
-                            this.barcodeResults.Remove(barcode);
-                        }
-                    }
+                    this.barcodeResults.RemoveWhere(b => !previewRect.Contains(b.PreviewBoundingBox));
                 }
 
                 this.cameraView.DetectionFinished(this.barcodeResults.ToArray());


### PR DESCRIPTION
Replace foreach+Remove with RemoveWhere in both iOS and Android CameraManager
to prevent InvalidOperationException being silently swallowed when AimMode or
ViewfinderMode filters are active, which caused DetectionFinished to never fire
for affected frames.

Also extend iOS BarcodeFormatMapper ITF mapping to include I2OF5 and
I2OF5Checksum symbologies alongside Itf14, aligning iOS behaviour with Android
where BarcodeFormats.ITF covers all variable-length Interleaved 2-of-5 barcodes.
